### PR TITLE
Fix for many pictures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# PhpStorm
+/.idea
+
 vendor
 build
 composer.lock

--- a/src/Driver/SimpleXML.php
+++ b/src/Driver/SimpleXML.php
@@ -46,6 +46,7 @@ class SimpleXML implements DriverInterface {
 
             $arr = $this->getElementAttributes($offer);
             $arr['params'] = $this->parseParamsFromElement($offer);
+            $arr['pictures'] = $this->parsePicturesFromElement($offer);
 
             foreach ($offer->children() as $element) {
                 $name = mb_strtolower($element->getName());
@@ -133,6 +134,26 @@ class SimpleXML implements DriverInterface {
                 $returnArr[] = array_merge(
                         ['value' => (string) $element], $this->getElementAttributes($element)
                 );
+            }
+        }
+
+        return $returnArr;
+    }
+
+    /**
+     * Gets element pictures.
+     *
+     * @param \SimpleXMLElement $offer
+     *
+     * @return array
+     */
+    private function parsePicturesFromElement(\SimpleXMLElement $offer) {
+        $returnArr = [];
+
+        foreach ($offer->children() as $element) {
+
+            if (mb_strtolower($element->getName()) == 'picture') {
+                $returnArr[] = (string) $element;
             }
         }
 

--- a/src/Driver/XMLReader.php
+++ b/src/Driver/XMLReader.php
@@ -126,6 +126,10 @@ class XMLReader implements DriverInterface {
                                 if ($name == 'param') {
                                     $arr['params'][] = array_merge(['value' => $xml->value], $tmpArr);
                                 } else {
+                                    if ($name == 'picture') {
+                                        $arr['pictures'][] = $xml->value;
+                                    }
+
                                     $arr[$name] = $xml->value;
                                 }
                             }

--- a/tests/fixtures/valid_xml.xml
+++ b/tests/fixtures/valid_xml.xml
@@ -28,6 +28,8 @@
                 <currencyId>RUR</currencyId>
                 <categoryId>5707</categoryId>
                 <picture>http://mycompany.com/pictures/product/big/3858_big.jpg</picture>
+                <picture>http://mycompany.com/pictures/product/big/3858_big_2.jpg</picture>
+                <picture>http://mycompany.com/pictures/product/big/3858_big_3.jpg</picture>
                 <delivery>true</delivery>
                 <!-- Comment block for testing filter function on getOffers() method
                     <vendor>Makita</vendor>

--- a/tests/unit/Driver/SimpleXML.php
+++ b/tests/unit/Driver/SimpleXML.php
@@ -47,6 +47,7 @@ class YMLParser_Driver_SimpleXML extends PHPUnit_Framework_TestCase {
 
         $this->assertNotEmpty($result);
         $this->assertEquals(5, count($result));
+        $this->assertEquals(3, count($result[0]['pictures']));
         $this->assertTrue($result[0] instanceof \YMLParser\Node\Offer);
         $this->assertTrue(is_numeric($result[0]->getPrice()));
     }

--- a/tests/unit/Driver/XMLReader.php
+++ b/tests/unit/Driver/XMLReader.php
@@ -41,6 +41,7 @@ class YMLParser_Driver_XMLReader extends PHPUnit_Framework_TestCase {
 
         $this->assertNotEmpty($result);
         $this->assertEquals(5, count($result));
+        $this->assertEquals(3, count($result[0]['pictures']));
         $this->assertTrue($result[0] instanceof \YMLParser\Node\Offer);
         $this->assertTrue(is_numeric($result[0]->getPrice()));
     }


### PR DESCRIPTION
Hi, Alexander!

In one of my projects we have simple yml-file with many `picture` tags in offer:

``` xml
<offer id="12395" available="true" type="vendor.model">
    <url>http://mycompany.com/products/stabilizator-napriazheniia-resanta-ach2000-n1ts</url>
    <price>3970</price>
    <currencyId>RUR</currencyId>
    <categoryId>5707</categoryId>
    <picture>http://mycompany.com/pictures/product/big/3858_big.jpg</picture>
    <picture>http://mycompany.com/pictures/product/big/3858_big_2.jpg</picture>
    <picture>http://mycompany.com/pictures/product/big/3858_big_3.jpg</picture>
```

I looked Yandex.Market documentation and don't found any comments about count of `picture` tags in one offer (think I don't alone and this really maybe in any projects).

This PR fix this problem and give for developers virtual key in offer `pictures`.

In source we may do this:

``` php
$parser = new \YMLParser\YMLParser(new \YMLParser\Driver\XMLReader);
$parser->open($filename); // throws \Exception if $filename doesn't exist or empty
foreach($parser->getOffers() as $offer): // YMLParser::getOffers() returns \Generator
    if (isset($offer['pictures']) && count($offer['pictures']) > 1)
    {
        // do anythings with $offer['pictures']
    }
    else
    {
        // do anythings with $offer['picture']
    }
endforeach;

// OR

$parser = new \YMLParser\YMLParser(new \YMLParser\Driver\SimpleXML);
$parser->open($filename); // throws \Exception if $filename doesn't exist or empty
foreach($parser->getOffers() as $offer): // YMLParser::getOffers() returns \Generator
    if (isset($offer['pictures']) && count($offer['pictures']) > 1)
    {
        // do anythings with $offer['pictures']
    }
    else
    {
        // do anythings with $offer['picture']
    }
endforeach;
```

I add small tests for this PR and if you see any more tests I will be add its.
